### PR TITLE
Should demucs be run with -j num_cpus to speed it up?

### DIFF
--- a/src/allin1/demix.py
+++ b/src/allin1/demix.py
@@ -1,6 +1,8 @@
 import sys
 import subprocess
 import torch
+import os
+NUM_CPUS = os.cpu_count()
 
 from pathlib import Path
 from typing import List, Union
@@ -33,6 +35,7 @@ def demix(paths: List[Path], demix_dir: Path, device: Union[str, torch.device]):
         '--out', demix_dir.as_posix(),
         '--name', 'htdemucs',
         '--device', str(device),
+        '-j', str(NUM_CPUS),
         *[path.as_posix() for path in todos],
       ],
       check=True,

--- a/src/allin1/demix.py
+++ b/src/allin1/demix.py
@@ -1,11 +1,12 @@
+import os
 import sys
 import subprocess
 import torch
-import os
-NUM_CPUS = os.cpu_count()
 
 from pathlib import Path
 from typing import List, Union
+
+NUM_CPUS = os.cpu_count()
 
 
 def demix(paths: List[Path], demix_dir: Path, device: Union[str, torch.device]):
@@ -35,7 +36,7 @@ def demix(paths: List[Path], demix_dir: Path, device: Union[str, torch.device]):
         '--out', demix_dir.as_posix(),
         '--name', 'htdemucs',
         '--device', str(device),
-        '-j', str(NUM_CPUS),
+        '--jobs', str(NUM_CPUS),
         *[path.as_posix() for path in todos],
       ],
       check=True,


### PR DESCRIPTION
Thank you for the awesome library.

I wonder if running demucs in https://github.com/mir-aidj/all-in-one/blob/ea51ed313a573e93a3599fca55578aa9179b3a6f/src/allin1/demix.py#L32
may benefit from adding `--jobs` flag in case there's no GPU present? I run it [in HuggingFace](https://huggingface.co/spaces/vpavlenko/all-in-one), and I get a two-fold boost on CPU UPGRADE (8 vCPUs compared to 2 vCPUs in the free Spaces)

(For the context of how I use it: I copy the link of the output archive from Hugging Face ("Compressed Files") and paste it into the edit field of https://music-dissector.vercel.app/)